### PR TITLE
Solution for threads that don't end

### DIFF
--- a/bot/TydiriumServer.py
+++ b/bot/TydiriumServer.py
@@ -67,9 +67,11 @@ def startControllPanel(panel):
     print("Server started http://%s:%s" % (HOST_NAME, PORT))
     try:
         while True:
-            th = Thread(target=panel.serve_forever)
+            th = Thread(target=panel.serve_forever, name="Tydirium server")
             th.start()
             th.join(timeout=SERVER_LIFETIME)
+            if th.is_alive():
+                panel.shutdown()
     except KeyboardInterrupt:
         panel.server_close()
         print("Server stopped.")


### PR DESCRIPTION
Solution for Issue #8

In file tydirium_server.py, line 72:
`thread.join(timeout=SERVER_LIFETIME)` method waits until thread ends or for SERVER_LIFETIME seconds (but doesn't end the thread).
If the server stops before SERVER_LIFETIME, then it should start again due to the while loop.
If nothing unexpected happens the server will be closed (lines 73-74) and will start again due to the while loop.

An alternative for this solution would be to just run `serve_forever` one time, bat it would be a bigger change.