### PR TITLE
if the server is still working, then shutdown the server

### DIFF
--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -69,9 +69,11 @@ def start_controll_panel(panel):
     print(f"Server started http://{HOST_NAME}:{PORT}")
     try:
         while True:
-            thread = Thread(target=panel.serve_forever)
+            thread = Thread(target=panel.serve_forever, name="Tydirium server")
             thread.start()
             thread.join(timeout=SERVER_LIFETIME)
+            if thread.is_alive():
+                panel.shutdown()
     except KeyboardInterrupt:
         panel.server_close()
         print("Server stopped.")


### PR DESCRIPTION
Makes the same as pull request #9 but on top of code_cleanup1


Solution to Issue #8

In file tydirium_server.py, line 74:
`thread.join(timeout=SERVER_LIFETIME)` method waits until thread ends or for SERVER_LIFETIME seconds (but doesn't end the thread).
If the server stops before SERVER_LIFETIME, then it should start again due to the while loop.
If nothing unexpected happens the server will be closed and will start again due to the while loop.

An alternative for this solution would be to just run `serve_forever` one time, bat it would be a bigger change.