### PR TITLE
Track door statistics

### DIFF
--- a/bot/firmus_piett.py
+++ b/bot/firmus_piett.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime, timedelta
 import discord
 from discord.ext import tasks
-from bot.server_client import get_door_state
+from bot.server_client import ServerClient
 
 
 HOST_NAME = "localhost"
@@ -17,16 +17,12 @@ NEW_CODE = "new code"
 REPORT = "report"
 
 
-
-class FirmusPiett(discord.Client):
+class FirmusPiett(discord.Client, ServerClient):
     """
     Main class for maintaining discord bot.
     Responsible for correct displaying state of the door as bot status
     and responding for users commands.
     """
-
-    host_name: str
-    port: int
 
     class Communicate:
         """
@@ -75,16 +71,12 @@ class FirmusPiett(discord.Client):
         self._last_code = -1
         self._communicate = FirmusPiett.Communicate()
         self.last_update = None
-        if host == "":
-            self.host_name = "localhost"
-        else:
-            self.host_name = host
-        self.port = port
+        ServerClient.__init__(self, host, port)
 
     @tasks.loop(seconds=REFRESH_TIME)
     async def refresh_status(self):
         now = datetime.now()
-        door_state, self.last_update = get_door_state(self.host_name, self.port)
+        door_state, self.last_update = self.get_door_state()
         if self.last_update is not None and (now - self.last_update) > PATIENCE:
             door_state = -1
         if self._last_code != door_state:

--- a/bot/server_client.py
+++ b/bot/server_client.py
@@ -5,8 +5,15 @@ DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 def get_door_state(host, port):
-    request = requests.get(f"http://{host}:{port}")
+    request = requests.get(f"http://{host}:{port}/door-state")
     content = request.text.split('\n')
     door_state = int(content[0])
     last_update = datetime.strptime(content[1], DATE_FORMAT)
     return door_state, last_update
+
+
+def get_door_state_prediction(host, port):
+    request = requests.get(f"http://{host}:{port}/door-state-prediction")
+    content = request.text.split('\n')
+    door_state = int(content[0])
+    return door_state

--- a/bot/server_client.py
+++ b/bot/server_client.py
@@ -4,16 +4,26 @@ import requests
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-def get_door_state(host, port, timeout=10.0):
-    request = requests.get(f"http://{host}:{port}/door-state", timeout=timeout)
-    content = request.text.split('\n')
-    door_state = int(content[0])
-    last_update = datetime.strptime(content[1], DATE_FORMAT)
-    return door_state, last_update
+class ServerClient:
+    host: str
+    port: int
 
+    def __init__(self, host: str, port: int):
+        if host == "":
+            self.host = "localhost"
+        else:
+            self.host = host
+        self.port = port
 
-def get_door_state_prediction(host, port, timeout=10.0):
-    request = requests.get(f"http://{host}:{port}/door-state-prediction", timeout=timeout)
-    content = request.text.split('\n')
-    door_state = int(content[0])
-    return door_state
+    def get_door_state(self, timeout=10.0):
+        request = requests.get(f"http://{self.host}:{self.port}/door-state", timeout=timeout)
+        content = request.text.split('\n')
+        door_state = int(content[0])
+        last_update = datetime.strptime(content[1], DATE_FORMAT)
+        return door_state, last_update
+
+    def get_door_state_prediction(self, timeout=10.0):
+        request = requests.get(f"http://{self.host}:{self.port}/door-state-prediction", timeout=timeout)
+        content = request.text.split('\n')
+        door_state = int(content[0])
+        return door_state

--- a/bot/server_client.py
+++ b/bot/server_client.py
@@ -22,8 +22,21 @@ class ServerClient:
         last_update = datetime.strptime(content[1], DATE_FORMAT)
         return door_state, last_update
 
-    def get_door_state_prediction(self, timeout=10.0):
-        request = requests.get(f"http://{self.host}:{self.port}/door-state-prediction", timeout=timeout)
-        content = request.text.split('\n')
-        door_state = int(content[0])
+    def get_door_state_prediction(self, when: datetime, timeout=10.0):
+        header = {"Date-Time": when.strftime(DATE_FORMAT)}
+        request = requests.get(f"http://{self.host}:{self.port}/door-state-prediction", headers=header, timeout=timeout)
+        door_state = float(request.text)
         return door_state
+
+    def get_door_state_prediction_for_now(self, timeout=10.0):
+        return self.get_door_state_prediction(datetime.now(), timeout=timeout)
+
+    def post_door_state_prediction(self, day_of_week: int, hour: int, data_array, timeout=10.0):
+        # data should be passed as a 1d-array that can be accessed by data_array[i]
+        # each element of data_array should be a float, support por round function is needed
+        message = ""
+        for i in range(60):
+            message += f"{round(data_array[i], ndigits=3)} "
+        headers = {"Day-Of-Week": str(day_of_week), "Hour": str(hour)}
+        requests.post(f"http://{self.host}:{self.port}/post/door-state-prediction", data=message, headers=headers,
+                      timeout=timeout)

--- a/bot/server_client.py
+++ b/bot/server_client.py
@@ -4,16 +4,16 @@ import requests
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-def get_door_state(host, port):
-    request = requests.get(f"http://{host}:{port}/door-state")
+def get_door_state(host, port, timeout=10.0):
+    request = requests.get(f"http://{host}:{port}/door-state", timeout=timeout)
     content = request.text.split('\n')
     door_state = int(content[0])
     last_update = datetime.strptime(content[1], DATE_FORMAT)
     return door_state, last_update
 
 
-def get_door_state_prediction(host, port):
-    request = requests.get(f"http://{host}:{port}/door-state-prediction")
+def get_door_state_prediction(host, port, timeout=10.0):
+    request = requests.get(f"http://{host}:{port}/door-state-prediction", timeout=timeout)
     content = request.text.split('\n')
     door_state = int(content[0])
     return door_state

--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -28,22 +28,7 @@ class ControllPanel(BaseHTTPRequestHandler):
     def do_POST(self): # pylint: disable=C0103
         print("I got POST")
 
-        def accept_post():
-            try:
-                self.send_response(200)
-                self.send_header('Content-Type', 'text/html')
-                self.end_headers()
-                # reads ONLY one byte (works as long as only one service is connecting)
-                body = self.rfile.read(1)
-                ControllPanel.code_blue = ControllPanel.parse_as_expected(body)
-                ControllPanel.last_update = datetime.now()
-                output = ""
-                self.wfile.write(output.encode())
-                print("Received code:", ControllPanel.code_blue)
-            except:
-                self.send_error(404, f"{sys.exc_info()[0]}")
-                print(sys.exc_info())
-        serve_process = Process(target=accept_post, args={})
+        serve_process = Process(target=self.accept_post, args={})
         serve_process.start()
         serve_process.join(timeout=HTTP_TIMEOUT)
         if serve_process.is_alive():
@@ -74,6 +59,22 @@ class ControllPanel(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(message)))
         self.end_headers()
         self.wfile.write(message)
+
+    def accept_post(self):
+        try:
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            # reads ONLY one byte (works as long as only one service is connecting)
+            body = self.rfile.read(1)
+            ControllPanel.code_blue = ControllPanel.parse_as_expected(body)
+            ControllPanel.last_update = datetime.now()
+            output = ""
+            self.wfile.write(output.encode())
+            print("Received code:", ControllPanel.code_blue)
+        except:
+            self.send_error(404, f"{sys.exc_info()[0]}")
+            print(sys.exc_info())
 
 
 def start_controll_panel(panel):

--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -27,12 +27,7 @@ class ControlPanel(BaseHTTPRequestHandler):
 
     def do_POST(self): # pylint: disable=C0103
         print("I got POST")
-
-        serve_process = Process(target=self.accept_post, args={})
-        serve_process.start()
-        serve_process.join(timeout=HTTP_TIMEOUT)
-        if serve_process.is_alive():
-            serve_process.terminate()
+        self.accept_post()
 
     def do_GET(self): # pylint: disable=C0103
         if self.path == "/door-state":

--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -13,7 +13,7 @@ SERVER_LIFETIME = 300  # in seconds
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
-class ControllPanel(BaseHTTPRequestHandler):
+class ControlPanel(BaseHTTPRequestHandler):
     """
     Main HTTP server.
     Responsible for receiving posts from sensor (Tydirium)
@@ -67,17 +67,17 @@ class ControllPanel(BaseHTTPRequestHandler):
             self.end_headers()
             # checks the Content-Length and reads the whole message
             body = self.rfile.read(int(self.headers["Content-Length"]))
-            ControllPanel.code_blue = ControllPanel.parse_as_expected(body)
-            ControllPanel.last_update = datetime.now()
+            ControlPanel.code_blue = ControlPanel.parse_as_expected(body)
+            ControlPanel.last_update = datetime.now()
             output = ""
             self.wfile.write(output.encode())
-            print("Received code:", ControllPanel.code_blue)
+            print("Received code:", ControlPanel.code_blue)
         except:
             self.send_error(404, f"{sys.exc_info()[0]}")
             print(sys.exc_info())
 
 
-def start_controll_panel(panel):
+def start_control_panel(panel):
     print(f"Server started http://{HOST_NAME}:{PORT}")
     try:
         while True:
@@ -92,5 +92,5 @@ def start_controll_panel(panel):
 
 
 if __name__ == "__main__":
-    server = HTTPServer((HOST_NAME, PORT), ControllPanel)
-    start_controll_panel(server)
+    server = HTTPServer((HOST_NAME, PORT), ControlPanel)
+    start_control_panel(server)

--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -50,12 +50,13 @@ class ControllPanel(BaseHTTPRequestHandler):
             serve_process.terminate()
 
     def do_GET(self): # pylint: disable=C0103
-        self.send_response(200)
-        self.send_header('Content-type', 'text/html')
-        self.end_headers()
-
-        message = self.generate_door_state_message()
-        self.wfile.write(bytes(message, "utf8"))
+        if self.path == "/door-state":
+            message = bytes(self.generate_door_state_message(), "utf8")
+        elif self.path == "/door-state-prediction":
+            message = bytes("-1", "utf8")
+        else:
+            message = bytes(f"The path {self.path} is unknown. Try /door-state", "utf8")
+        self.respond_with_this_message(message)
 
     @staticmethod
     def parse_as_expected(body):
@@ -66,6 +67,13 @@ class ControllPanel(BaseHTTPRequestHandler):
 
     def generate_door_state_message(self) -> str:
         return str(self.code_blue) + "\n" + self.last_update.strftime(DATE_FORMAT)
+
+    def respond_with_this_message(self, message: bytes):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.send_header("Content-Length", str(len(message)))
+        self.end_headers()
+        self.wfile.write(message)
 
 
 def start_controll_panel(panel):

--- a/bot/tydirium_server.py
+++ b/bot/tydirium_server.py
@@ -65,8 +65,8 @@ class ControllPanel(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-Type', 'text/html')
             self.end_headers()
-            # reads ONLY one byte (works as long as only one service is connecting)
-            body = self.rfile.read(1)
+            # checks the Content-Length and reads the whole message
+            body = self.rfile.read(int(self.headers["Content-Length"]))
             ControllPanel.code_blue = ControllPanel.parse_as_expected(body)
             ControllPanel.last_update = datetime.now()
             output = ""

--- a/door_stats/analyse_data.py
+++ b/door_stats/analyse_data.py
@@ -35,6 +35,8 @@ class DataAnalyzer(ServerClient):
     # given a file list returns the prediction for that particular hour
     @staticmethod
     def make_predictions_for_given_file_list(file_list: list) -> np.ndarray:
+        if not file_list:
+            return np.full(60, -1.0)
         all_data = np.zeros((60, len(file_list)), dtype='int32')
         for i in range(len(file_list)):
             all_data[:, i] = np.loadtxt(file_list[i], dtype='int32')

--- a/door_stats/analyse_data.py
+++ b/door_stats/analyse_data.py
@@ -1,0 +1,92 @@
+import numpy as np
+from bot.server_client import ServerClient
+from os import listdir
+from os.path import join, isfile
+from datetime import date, timedelta
+
+
+class DataAnalyzer(ServerClient):
+
+    def make_and_post_weekly_predictions(self, dir_path, n_weeks=4):
+        for week_day in range(1, 8):
+            for hour in range(24):
+                pred = self.make_recent_predictions(dir_path, week_day, hour, n_weeks)
+                self.post_door_state_prediction(week_day, hour, pred)
+
+    def make_and_post_predictions_for_yesterday(self, dir_path, n_weeks=4):
+        yesterday = date.today().isoweekday() - 1
+        if yesterday == 0:
+            yesterday = 7
+        for hour in range(24):
+            pred = self.make_recent_predictions(dir_path, yesterday, hour, n_weeks)
+            self.post_door_state_prediction(yesterday, hour, pred)
+    
+    def make_and_post_predictions_valid_for_given_day(self, dir_path, for_when: date, n_weeks=4):
+        for hour in range(24):
+            files = self.get_list_of_files(dir_path, for_when.isoweekday(), hour, n_weeks, for_when)
+            pred = self.make_predictions_for_given_file_list(files)
+            self.post_door_state_prediction(for_when.isoweekday(), hour, pred)
+
+    @staticmethod
+    def make_recent_predictions(dir_path, day_of_week: int, hour: int, n_weeks) -> np.ndarray:
+        file_list = DataAnalyzer.get_recent_files(dir_path, day_of_week, hour, n_weeks)
+        return DataAnalyzer.make_predictions_for_given_file_list(file_list)
+
+    # given a file list returns the prediction for that particular hour
+    @staticmethod
+    def make_predictions_for_given_file_list(file_list: list) -> np.ndarray:
+        all_data = np.zeros((60, len(file_list)))
+        for i in range(len(file_list)):
+            all_data[:, i] = np.loadtxt(file_list[i])
+        # if data was missing than replace it with np.nan
+        all_data[all_data < 0.0] = np.nan
+        output = np.mean(all_data, axis=1)
+        # if all data for a given point was missing, replace np.nan with -1.0
+        output[output is np.nan] = -1.0
+        return output
+
+    # finds the date of last day_of_week, returns ref_date if day of week is correct
+    @staticmethod
+    def get_last_day_of_week(ref_date: date, day_of_week: int) -> date:
+        days_diff = ref_date.isoweekday() - day_of_week
+        if days_diff < 0:
+            days_diff = 7 - days_diff
+        return ref_date - timedelta(days=days_diff)
+
+    # methods to find wanted file paths
+    @staticmethod
+    def get_recent_files(dir_path, day_of_week: int, hour: int, n_weeks: int) -> list:
+        return DataAnalyzer.get_list_of_files(dir_path, day_of_week, hour, n_weeks, date.today())
+
+    @staticmethod
+    def get_list_of_files(dir_path, day_of_week: int, hour: int, n_weeks: int, ref_date: date) -> list:
+        last_date = DataAnalyzer.get_last_day_of_week(ref_date, day_of_week) - timedelta(days=7*n_weeks)
+
+        day_of_week = str(day_of_week)
+        hour = str(hour).zfill(2)
+        interesting_files = []
+        for i in listdir(dir_path):
+            if not isfile(join(dir_path, i)):
+                continue
+            # first check if day of week and hour matches, then check if date is ok
+            if i.startswith(f"{day_of_week}_{hour}_"):
+                if last_date <= date(*(int(j) for j in i[5:15].split('-'))) <= ref_date:
+                    interesting_files.append(join(dir_path, i))
+        return interesting_files
+
+    @staticmethod
+    def get_list_of_all_files(dir_path, day_of_week: int, hour: int) -> list:
+        day_of_week = str(day_of_week)
+        hour = str(hour).zfill(2)
+        interesting_files = []
+        for i in listdir(dir_path):
+            if not isfile(join(dir_path, i)):
+                continue
+            if i.startswith(f"{day_of_week}_{hour}_"):
+                interesting_files.append(join(dir_path, i))
+        return interesting_files
+
+
+if __name__ == '__main__':
+    data_analyzer = DataAnalyzer("localhost", 7216)
+    data_analyzer.make_and_post_predictions_for_yesterday("./data", n_weeks=4)

--- a/door_stats/analyse_data.py
+++ b/door_stats/analyse_data.py
@@ -35,14 +35,15 @@ class DataAnalyzer(ServerClient):
     # given a file list returns the prediction for that particular hour
     @staticmethod
     def make_predictions_for_given_file_list(file_list: list) -> np.ndarray:
-        all_data = np.zeros((60, len(file_list)))
+        all_data = np.zeros((60, len(file_list)), dtype='int32')
         for i in range(len(file_list)):
-            all_data[:, i] = np.loadtxt(file_list[i])
-        # if data was missing than replace it with np.nan
-        all_data[all_data < 0.0] = np.nan
-        output = np.mean(all_data, axis=1)
+            all_data[:, i] = np.loadtxt(file_list[i], dtype='int32')
+        output = np.zeros(60)
+        for i in range(60):
+            this_hour_data = all_data[i, :]
+            output[i] = np.mean(this_hour_data[this_hour_data >= 0])
         # if all data for a given point was missing, replace np.nan with -1.0
-        output[output is np.nan] = -1.0
+        output[np.isnan(output)] = -1.0
         return output
 
     # finds the date of last day_of_week, returns ref_date if day of week is correct

--- a/door_stats/door_tracker.py
+++ b/door_stats/door_tracker.py
@@ -1,4 +1,4 @@
-from bot.server_client import get_door_state
+from bot.server_client import ServerClient
 from datetime import datetime, date, timedelta
 from time import time, sleep
 import sched
@@ -6,16 +6,13 @@ import numpy as np
 from threading import Thread
 
 
-class DoorStateTracker:
-    host: str
-    port: int
+class DoorStateTracker(ServerClient):
     door_state: int
     last_update: datetime
     data_validation_time = timedelta(seconds=300)
 
     def __init__(self, host: str, port: int):
-        self.host = host
-        self.port = port
+        ServerClient.__init__(self, host, port)
 
     def gather_hour_data(self, day: date, hour: int, output_dir_path) -> None:
         # check if a delay is needed before running
@@ -30,7 +27,7 @@ class DoorStateTracker:
         for i in range(60):
             star_time = time()
             # get new data and save them if valid
-            self.door_state, self.last_update = get_door_state(self.host, self.port, timeout=10.0)
+            self.door_state, self.last_update = self.get_door_state(timeout=10.0)
             if self.is_door_state_valid():
                 data[i] = self.door_state
             else:

--- a/door_stats/door_tracker.py
+++ b/door_stats/door_tracker.py
@@ -1,0 +1,95 @@
+from bot.server_client import get_door_state
+from datetime import datetime, date, timedelta
+from time import time, sleep
+import sched
+import numpy as np
+from threading import Thread
+
+
+class DoorStateTracker:
+    host: str
+    port: int
+    door_state: int
+    last_update: datetime
+    data_validation_time = timedelta(seconds=300)
+
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+
+    def gather_hour_data(self, day: date, hour: int, output_dir_path) -> None:
+        # check if a delay is needed before running
+        # or if it isn't too late to start, up to 30 seconds too late is allowed
+        time_to_start = self.time_left_to_start(day, hour)
+        if time_to_start < -30:
+            return None
+        elif time_to_start > 0:
+            sleep(time_to_start)
+        # gather data
+        data = np.full(60, -2)
+        for i in range(60):
+            star_time = time()
+            # get new data and save them if valid
+            self.door_state, self.last_update = get_door_state(self.host, self.port, timeout=10.0)
+            if self.is_door_state_valid():
+                data[i] = self.door_state
+            else:
+                data[i] = -1
+            # wait about a minute
+            time_so_sleep = 60.0 - (time() - star_time)
+            if time_so_sleep < 0.0:
+                raise RuntimeError
+            sleep(time_so_sleep)
+        # save gathered data
+        file_name = self.generate_hour_file_name(day, hour)
+        np.savetxt(f"{output_dir_path}/{file_name}", data, fmt='%i')
+
+    def schedule_daily_runs(self, day: date, out_path, starting_hour=0, ending_hour=23) -> Thread:
+        now = datetime.now()
+        if now.date() > day:
+            raise RuntimeError
+        elif now.date() == day:
+            starting_hour = max(starting_hour, now.hour)
+
+        # schedule all events to start at correct time
+        s = sched.scheduler(time, sleep)
+        for hour in range(starting_hour, ending_hour+1):
+            # if an event should have already started, schedule it to run immediately
+            time_to_start = max(self.time_left_to_start(day, hour), 0.0)
+            s.enter(time_to_start, 1, self.gather_hour_data, argument=(day, hour, out_path))
+
+        th = Thread(target=self.run_scheduled_data_gathering, name="scheduled runs", args=(s,))
+        th.start()
+        return th
+
+    def is_door_state_valid(self) -> bool:
+        if datetime.now() - self.last_update < self.data_validation_time:
+            return True
+        return False
+
+    @staticmethod
+    def generate_hour_file_name(day: date, hour: int) -> str:
+        if 0 <= hour < 24:
+            file_name = f"{day.isoweekday()}_{str(hour).zfill(2)}_{day.isoformat()}.csv"
+            return file_name
+        return "incorrect.csv"
+
+    @staticmethod
+    def time_left_to_start(day: date, hour: int) -> float:
+        now = datetime.now()
+        when_to_start = datetime(year=day.year, month=day.month, day=day.day, hour=hour, minute=0, second=0)
+        time_to_start = when_to_start - now
+        return time_to_start.total_seconds()
+
+    @staticmethod
+    def run_scheduled_data_gathering(s: sched.scheduler) -> None:
+        try:
+            s.run()
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == '__main__':
+    ds = DoorStateTracker("localhost", 7216)
+    scheduled_data_gathering = ds.schedule_daily_runs(date.today(), "./data")
+    scheduled_data_gathering.join()

--- a/door_stats/door_tracker.py
+++ b/door_stats/door_tracker.py
@@ -27,7 +27,10 @@ class DoorStateTracker(ServerClient):
         for i in range(60):
             star_time = time()
             # get new data and save them if valid
-            self.door_state, self.last_update = self.get_door_state(timeout=10.0)
+            try:
+                self.door_state, self.last_update = self.get_door_state(timeout=10.0)
+            except:
+                pass
             if self.is_door_state_valid():
                 data[i] = self.door_state
             else:

--- a/door_stats/door_tracker.py
+++ b/door_stats/door_tracker.py
@@ -35,7 +35,9 @@ class DoorStateTracker(ServerClient):
                 data[i] = self.door_state
             else:
                 data[i] = -1
-            # wait about a minute
+            if i == 59:
+                break
+            # if ins not the last datapoint, wait about a minute
             time_so_sleep = 60.0 - (time() - star_time)
             if time_so_sleep < 0.0:
                 raise RuntimeError

--- a/door_stats/example_data_gathering.sh
+++ b/door_stats/example_data_gathering.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd ~/Tydirium/
+
+source door-stats-venv/bin/activate
+
+DATE=$(date +%Y-%m-%d)
+HOST="localhost"
+PORT=7216
+OUTPUTPATH="./data"
+nohup python run_data_gathering.py $DATE $HOST $PORT $OUTPUTPATH > /dev/null 2> door-stats.log &

--- a/door_stats/example_upload_predictions.sh
+++ b/door_stats/example_upload_predictions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd ~/Tydirium/
+
+source door-stats-venv/bin/activate
+
+HOST="localhost"
+PORT=7216
+OUTPUTPATH="./data"
+python upload_predictions.py $HOST $PORT $OUTPUTPATH > /dev/null 2> door-stats.log

--- a/run_data_gathering.py
+++ b/run_data_gathering.py
@@ -1,0 +1,40 @@
+from threading import Thread
+from door_stats.door_tracker import DoorStateTracker
+from datetime import date
+import sys
+
+
+def run_daily_door_state_gathering(day: date, host: str, port: int, out_path: str) -> None:
+    ds = DoorStateTracker(host, port)
+    scheduled_data_gathering = ds.schedule_daily_runs(day, out_path)
+    scheduled_data_gathering.join()
+
+
+def parse_args() -> tuple:
+    day = date.today()
+    host = "localhost"
+    port = 7216
+    out_path = "./data"
+
+    if len(sys.argv) > 1:
+        day = date(*(int(i) for i in sys.argv[1].split('-')))
+    if len(sys.argv) > 2:
+        host = sys.argv[2]
+    if len(sys.argv) > 3:
+        port = int(sys.argv[3])
+    if len(sys.argv) > 4:
+        out_path = sys.argv[4]
+
+    return day, host, port, out_path
+
+
+if __name__ == '__main__':
+    """
+    Args should be passed in the following order:
+        DAY HOST PORT OUTPUT_PATH
+    DAY format should be %Y-%m-%d
+    If some further arguments are missing, defaults are used:
+    DAY = today, HOST=localhost, PORT=7216, OUTPUT_PATH=./data
+    """
+    when, host_name, port_num, output_path = parse_args()
+    run_daily_door_state_gathering(when, host_name, port_num, output_path)

--- a/upload_predictions.py
+++ b/upload_predictions.py
@@ -1,0 +1,32 @@
+from threading import Thread
+from door_stats.door_tracker import DoorStateTracker
+from datetime import date
+import sys
+from door_stats.analyse_data import DataAnalyzer
+
+
+def parse_args() -> tuple:
+    host = "localhost"
+    port = 7216
+    data_path = "./data"
+
+    if len(sys.argv) > 1:
+        host = sys.argv[1]
+    if len(sys.argv) > 2:
+        port = int(sys.argv[2])
+    if len(sys.argv) > 3:
+        data_path = sys.argv[3]
+
+    return host, port, data_path
+
+
+if __name__ == '__main__':
+    """
+    Args should be passed in the following order:
+        HOST PORT OUTPUT_PATH
+    If some further arguments are missing, defaults are used:
+    HOST=localhost, PORT=7216, OUTPUT_PATH=./data
+    """
+    host_name, port_num, data_directory_path = parse_args()
+    data_analyzer = DataAnalyzer(host_name, port_num)
+    data_analyzer.make_and_post_predictions_for_yesterday(data_directory_path)


### PR DESCRIPTION
Solution for Issue #12.

Firstly I updated the server and server client to support door state predictions.
ServerClient is now a class not a bunch od functions. This was updated in firmus_piett.py.


Then I added a new part of the project stored in door_stats directory.

In door_stats/door_tracker.py there is a class DoorStateTracker that gets the door state from the server and saves it to files.
The data is gathered every minute and saved to files containing one hour of data each.
The idea was to make data analysis easier so the file name format is:
DayOfWeekISO_Hour_DateISO.csv
Just as we will need them later.

In door_stats/analyse_data.py there is a class DataAnalyzer that makes predictions based on files generated by DoorStateTracker. The logic is quite simple it just returns the average state of the door (-1 are removed first).
Then it posts the predictions to the server.

Usage:

DoorStateTracker should be started by cron (simplest variant is every day).
The script that cron should run may be similar to door_stats/example_data_gathering.sh
DoorStateTracker uses sched to schedule hour runs, so I suggests to run cron a day earlier (about 23:00) and schedule data gathering for the following day ( DATE=$(date --date="tomorrow" +%Y-%m-%d) ).

DataAnalyzer should run time to time to update the predictions on the server.
I thought about cron once a day to update the day of the week that just passed.
So cron should run something like door_stats/example_upload_predictions.sh every day (about 3:00 maybe).


